### PR TITLE
Feat(entity): 사용자, 출석 엔티티 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.idea/.gitignore

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Attendance/Attendance.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Attendance/Attendance.java
@@ -29,6 +29,22 @@ public class Attendance {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="member_id")
     private Member member;
+    // 처음 객체를 생성할 때
+    @PrePersist
+    protected void onCreate() {
+        this.date = LocalDate.now();
+        this.startTime = LocalTime.now();
+        this.total = 0L;
+    }
 
+    // 객체 호출 시점에 사용하기
+    protected void startCount(){
+        this.startTime = LocalTime.now();
+    }
+    // 누적 시간의 합을 구하는 메소드
+    protected void calculateAttendance(LocalTime endTime){
+        long minutes = java.time.Duration.between(this.startTime, endTime).toMinutes();
+        this.total += minutes; // 누적
+    }
 
 }

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Attendance/Attendance.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Attendance/Attendance.java
@@ -1,0 +1,34 @@
+package com.example.LabAttendance.RollCall.Attendance;
+
+import com.example.LabAttendance.RollCall.Member.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Attendance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    private LocalDate date; // 얘는 생성 시점에 결정, 그날의 날짜이기 때문
+
+    private LocalTime startTime; // 얘는 객체를 생성, 호출하는 시점에 할당
+
+    private Long total; // 객체 생성 시점에 0으로 할당.
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="member_id")
+    private Member member;
+
+
+}

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/Member.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/Member.java
@@ -1,0 +1,43 @@
+package com.example.LabAttendance.RollCall.Member;
+
+import com.example.LabAttendance.RollCall.Attendance.Attendance;
+import com.example.LabAttendance.RollCall.global.Gender;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId; // 학번
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private Gender gender;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Attendance> attandenceList = new ArrayList<>();
+}

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/global/Gender.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/global/Gender.java
@@ -1,0 +1,5 @@
+package com.example.LabAttendance.RollCall.global;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/backend/src/test/java/com/example/LabAttendance/RollCall/Attendance/AttendanceTest.java
+++ b/backend/src/test/java/com/example/LabAttendance/RollCall/Attendance/AttendanceTest.java
@@ -1,0 +1,30 @@
+package com.example.LabAttendance.RollCall.Attendance;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+public class AttendanceTest {
+
+    @Test
+    @DisplayName("랩실 잔류 시간 계산 해보기 ")
+    public void testAttendance() {
+        Attendance attendance = new Attendance();
+        attendance.onCreate();
+
+        attendance.startCount();
+        System.out.println("attendance.getStartTime() = " + attendance.getStartTime());
+        LocalTime endTime = LocalTime.now();
+
+        attendance.calculateAttendance(endTime);
+
+        Assertions.assertEquals(
+                attendance.getTotal(),
+                java.time.Duration.between(attendance.getStartTime(), endTime)
+                        .toMinutes());
+
+    }
+}


### PR DESCRIPTION
### 🔨작업 내용
- 사용자, 출석 엔티티 개발 
- 출석 엔티티에는 사용자의 랩실 잔류 시간을 계산하는 로직 추가 
- 잔류 시간을 계산하는 test 코드 추가

### ❗️관련된 이슈 
#15 

### 🤔고려사항
- 날짜가 넘어가는 시점에서 랩실 잔류 시간을 계산하기 위해 스케줄러 등록하기 