### PR TITLE
Feat : 로그인 로직 구현 및 Jwt를 이용한 인증토

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.h2database:h2'
 
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.h2database:h2'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/DTO/LoginRequestDto.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/DTO/LoginRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.LabAttendance.RollCall.Member.DTO;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDto(
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        String password
+) {}

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/DTO/LoginResponseDto.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/DTO/LoginResponseDto.java
@@ -3,7 +3,6 @@ package com.example.LabAttendance.RollCall.Member.DTO;
 public record LoginResponseDto(
         // 인증 토큰
         String accessToken,
-        String tokenType,
 
         Long memberId,
         String username,

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/DTO/LoginResponseDto.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/DTO/LoginResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.LabAttendance.RollCall.Member.DTO;
+
+public record LoginResponseDto(
+        // 인증 토큰
+        String accessToken,
+        String tokenType,
+
+        Long memberId,
+        String username,
+        String phone,
+        String email
+
+){
+
+}

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberController.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberController.java
@@ -23,14 +23,12 @@ public class MemberController
     public ResponseEntity<?> signup(@Valid @RequestBody MemberSignupRequestDto requestDto,
                                     BindingResult bindingResult)
     {
-
         if (bindingResult.hasErrors())
         {
             return ResponseEntity.badRequest().body(bindingResult.getFieldErrors());
         }
 
         MemberResponseDto responseDto;
-
         try
         {
             responseDto = memberService.create(requestDto);
@@ -39,7 +37,6 @@ public class MemberController
         {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
-
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
@@ -56,18 +53,19 @@ public class MemberController
         try
         {
             responseDto = memberService.login(loginRequestDto);
-
         }
         catch (MemberNotFoundException | BadCredentialsException e)
         {
-            // 이메일 불일치, 비밀번호 불일치 모두 401 Unauthorized 및 동일 메시지 반환
+            // 이메일 불일치, 비밀번호 불일치 오류는 401 반환
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
         catch (Exception e)
         {
+            // 500 오류 시, 상세한 오류 정보를 반환하여 디버깅을 돕습니다. (임시 코드)
+            e.printStackTrace(); // 서버 콘솔에 스택 트레이스를 출력
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("로그인 처리 중 서버 오류가 발생했습니다.");
+                    .body("서버 오류 발생: " + e.getMessage()); // Postman에 오류 메시지 노출
         }
 
         return ResponseEntity.ok(responseDto);

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberRepository.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberRepository.java
@@ -1,11 +1,14 @@
 package com.example.LabAttendance.RollCall.Member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
+
 public interface MemberRepository extends JpaRepository<Member,Long>
 {
     boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
 }
 

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberService.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberService.java
@@ -1,36 +1,30 @@
 package com.example.LabAttendance.RollCall.Member;
 
-import com.example.LabAttendance.RollCall.Member.DTO.LoginRequestDto;
-import com.example.LabAttendance.RollCall.Member.DTO.LoginResponseDto;
-import com.example.LabAttendance.RollCall.Member.DTO.MemberResponseDto;
-import com.example.LabAttendance.RollCall.Member.DTO.MemberSignupRequestDto;
-import com.example.LabAttendance.RollCall.global.DuplicateEmailException;
-import org.springframework.stereotype.Service;
+import com.example.LabAttendance.RollCall.Member.DTO.*;
+import com.example.LabAttendance.RollCall.global.*;
+import com.example.LabAttendance.RollCall.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.security.authentication.BadCredentialsException;
-import com.example.LabAttendance.RollCall.global.MemberNotFoundException;
 
 @RequiredArgsConstructor
 @Service
 @Transactional
+public class MemberService {
 
-public class MemberService
-{
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public MemberResponseDto create(MemberSignupRequestDto requestDto)
-    {
+    public MemberResponseDto create(MemberSignupRequestDto requestDto) {
 
         if (memberRepository.existsByEmail(requestDto.email())) {
             throw new DuplicateEmailException("이미 존재하는 이메일입니다: " + requestDto.email());
         }
 
-        String rawPassword = requestDto.password();
-        String hashedPassword = passwordEncoder.encode(rawPassword);
-
+        String hashedPassword = passwordEncoder.encode(requestDto.password());
 
         Member member = Member.builder()
                 .memberId(requestDto.memberId())
@@ -44,38 +38,31 @@ public class MemberService
         memberRepository.save(member);
 
         return new MemberResponseDto(
-                member.getId(),     // Long 타입 ID
+                member.getId(),
                 member.getMemberId(),
                 member.getNickname(),
                 member.getEmail()
         );
     }
 
-    public LoginResponseDto login(LoginRequestDto requestDto)
-    {
+    public LoginResponseDto login(LoginRequestDto requestDto) {
 
         Member member = memberRepository.findByEmail(requestDto.email())
                 .orElseThrow(() -> new MemberNotFoundException("가입되지 않은 이메일입니다."));
-
 
         if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
-        String generatedToken = "temp-jwt-token-for-user-" + member.getId();
+
+        String jwtToken = jwtTokenProvider.generateToken(member.getId(), member.getEmail());
 
         return new LoginResponseDto(
-                // 인증 토큰 관련 필드 (임시 값)
-                generatedToken,    // accessToken
-                "Bearer",          // tokenType
-
-                // 사용자 정보 필드
+                jwtToken,    // accessToken
                 member.getId(),
                 member.getNickname(),
                 member.getPhone(),
                 member.getEmail()
         );
     }
-
-
 }

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberService.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberService.java
@@ -1,15 +1,21 @@
 package com.example.LabAttendance.RollCall.Member;
 
+import com.example.LabAttendance.RollCall.Member.DTO.LoginRequestDto;
+import com.example.LabAttendance.RollCall.Member.DTO.LoginResponseDto;
 import com.example.LabAttendance.RollCall.Member.DTO.MemberResponseDto;
 import com.example.LabAttendance.RollCall.Member.DTO.MemberSignupRequestDto;
+import com.example.LabAttendance.RollCall.global.DuplicateEmailException;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.authentication.BadCredentialsException;
+import com.example.LabAttendance.RollCall.global.MemberNotFoundException;
 
 @RequiredArgsConstructor
 @Service
 @Transactional
+
 public class MemberService
 {
     private final MemberRepository memberRepository;
@@ -44,5 +50,32 @@ public class MemberService
                 member.getEmail()
         );
     }
+
+    public LoginResponseDto login(LoginRequestDto requestDto)
+    {
+
+        Member member = memberRepository.findByEmail(requestDto.email())
+                .orElseThrow(() -> new MemberNotFoundException("가입되지 않은 이메일입니다."));
+
+
+        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String generatedToken = "temp-jwt-token-for-user-" + member.getId();
+
+        return new LoginResponseDto(
+                // 인증 토큰 관련 필드 (임시 값)
+                generatedToken,    // accessToken
+                "Bearer",          // tokenType
+
+                // 사용자 정보 필드
+                member.getId(),
+                member.getNickname(),
+                member.getPhone(),
+                member.getEmail()
+        );
+    }
+
 
 }

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/SecurityConfig.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/SecurityConfig.java
@@ -1,18 +1,29 @@
 package com.example.LabAttendance.RollCall;
 
-// ... (다른 import 유지)
+import com.example.LabAttendance.RollCall.global.jwt.JwtAuthenticationFilter;
+import com.example.LabAttendance.RollCall.global.jwt.JwtTokenProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest; // ⭐ 이 import를 추가합니다.
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // JwtTokenProvider를 주입받아 사용합니다.
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -22,18 +33,35 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                // JWT를 사용하므로 CSRF 보호를 비활성화합니다.
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // JWT를 사용하므로 세션을 사용하지 않고 STATELESS로 설정
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                // H2 콘솔 접근을 위한 설정
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions.disable())
+                )
+
+                // 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
-                        // 1. PathRequest.toH2Console()을 사용하여 H2 콘솔 경로 허용
+                        // H2 Console 경로 허용
                         .requestMatchers(PathRequest.toH2Console()).permitAll()
+
+                        // 회원가입 및 로그인 경로는 인증 없이 접근 허용
+                        .requestMatchers("/lab/users/sign", "/lab/users/login").permitAll()
+
+                        // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )
-                .csrf(csrf -> csrf
-                        // 2. PathRequest.toH2Console()을 사용하여 CSRF 무시
-                        .ignoringRequestMatchers(PathRequest.toH2Console())
-                )
-                .headers(headers -> headers
-                        // 3. Frame Options 비활성화 유지 (H2 콘솔 사용)
-                        .frameOptions(frameOptions -> frameOptions.disable())
+
+                // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 이전에 등록합니다.
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/global/DuplicateEmailException.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/global/DuplicateEmailException.java
@@ -1,4 +1,4 @@
-package com.example.LabAttendance.RollCall.Member;
+package com.example.LabAttendance.RollCall.global;
 
 public class DuplicateEmailException extends RuntimeException {
     public DuplicateEmailException(String message) {

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/global/MemberNotFoundException.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/global/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.LabAttendance.RollCall.global;
+// RuntimeException을 상속받아 정의합니다.
+public class MemberNotFoundException extends RuntimeException {
+
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.example.LabAttendance.RollCall.global.jwt;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 로그인, 회원가입 경로는 JWT 인증을 건너뛰게 함
+        if (request.getRequestURI().equals("/lab/users/sign") || request.getRequestURI().equals("/lab/users/login")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // JWT 인증 처리
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);  // Bearer 부분을 제거하고 토큰만 반환
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/global/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,77 @@
+package com.example.LabAttendance.RollCall.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders; // Base64 디코더를 위해 필요합니다.
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Base64;
+
+@Component
+public class JwtTokenProvider {
+
+    // [중요 수정]: Base64 디코딩 오류를 방지하기 위해, Secret Key 자체를 Base64 인코딩된 문자열로 정의합니다.
+    // Base64 인코딩된 문자열은 'a' 대신 'b'와 같이 안전한 문자로만 구성됩니다.
+    // HS256 알고리즘 사용을 위해 최소 32바이트(256비트) 이상이어야 합니다.
+    private final String SECRET_KEY = Base64.getEncoder().encodeToString("MySuperSecretKeyForJwt1234567890!@#MySuperSecretKeyLongerThan32Bytes".getBytes());
+
+    private final long EXPIRATION = 1000 * 60 * 60 * 24; // 24시간
+
+    private Key getSigningKey() {
+        // Base64 문자열을 디코딩하여 바이트 배열을 얻고 Key 객체를 생성합니다.
+        // Base64 오류가 발생하지 않도록 안정적인 Decoders.BASE64를 사용합니다.
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateToken(Long userId, String email) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + EXPIRATION);
+
+        // Long 타입 ID를 String으로 변환하여 Claim에 추가 (Null 처리 및 안정성 확보)
+        String userIdString = (userId != null) ? userId.toString() : "";
+
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("userId", userIdString) // Long 대신 String으로 변경
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        String email = claims.getSubject();
+
+        return new UsernamePasswordAuthenticationToken(
+                email,
+                "",
+                Collections.emptyList()
+        );
+    }
+}


### PR DESCRIPTION
<img width="1704" height="1396" alt="image" src="https://github.com/user-attachments/assets/9729b5ab-9190-4575-a1f6-5af114f0f9fd" />
* 멤버 컨트롤러 로그인 로직 구현
: @PostMapping("/login")으로 매핑

* 멤버 컨트롤러 로그인 로직 구현
: 이메일이 DB에 있는지 확인
: 비밀번호(해시적용)이 DB에 있는지 확인
if 없을 시) 예외 처리
else ) LoginResponse(이메일, 학번, 이름, 휴대폰, 인증토큰 반환)

* 멤버 리포지터리 findByEmail()추가

* MemberNotFoundException 예외 처리 클래스 구현
: DB에 없을 시 이 예외 리턴


<img width="2550" height="1590" alt="image" src="https://github.com/user-attachments/assets/f7d43399-c2fb-40c3-9a3e-e0b54ad90f69" />
<img width="2552" height="1592" alt="image" src="https://github.com/user-attachments/assets/afe6e697-cbd0-4898-bd49-17ffb07517d7" />

### Feat : AccessToken Jwt로 구현하여 인증토큰 받기구현
* 이메일 비밀번호 일치 시 JwtTokenProvider로 토큰을 LoginResposeDto AccessToken에다가 줌.
JwtAuthenticationFilter로 JwtTokenProvicer로 토큰을 받았는지 아닌지 검사

* Token을 받고 LoginResponseDto 반환