### PR TITLE
Front/stipe/feat/#9

### DIFF
--- a/frontend/lib/HomeTab/Views/EditProfileView.dart
+++ b/frontend/lib/HomeTab/Views/EditProfileView.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/material.dart';
+import 'Profile_Service.dart';
+
+const Color primaryOrange = Color(0xFFE8823A);
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: '출석부 데모',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(seedColor: primaryOrange),
+      ),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  final ProfileService profileService = ProfileService();
+
+  String name = '';
+  String studentId = '';
+  String phone = '';
+  String email = '';
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfileData();
+  }
+
+  Future<void> _loadProfileData() async {
+    final profileData = await profileService.loadProfile();
+    if (mounted) {
+      setState(() {
+        name = profileData['name']!;
+        studentId = profileData['studentId']!;
+        phone = profileData['phone']!;
+        email = profileData['email']!;
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _resetProfile() async {
+    await profileService.clearProfile();
+    await _loadProfileData();
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('프로필이 초기화되었습니다.'), duration: Duration(seconds: 2)),
+      );
+    }
+  }
+
+  // 다이얼로그를 보여주는 함수가 매우 간결해졌습니다.
+  void _showEditProfileDialog() {
+    showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (context) {
+        // 별도로 분리된 다이얼로그 위젯을 호출합니다.
+        return EditProfileDialog(
+          initialName: name,
+          initialStudentId: studentId,
+          initialPhone: phone,
+          initialEmail: email,
+          onSave: (newName, newId, newPhone, newEmail) async {
+            // 저장 로직은 HomePage에서 그대로 처리합니다.
+            await profileService.saveProfile(
+              name: newName,
+              studentId: newId,
+              phone: newPhone,
+              email: newEmail,
+            );
+
+            if (mounted) {
+              setState(() {
+                name = newName;
+                studentId = newId;
+                phone = newPhone;
+                email = newEmail;
+              });
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('프로필이 저장되었습니다.'), duration: Duration(seconds: 2)),
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // HomePage의 UI 코드는 변경이 없습니다.
+    return Scaffold(
+      backgroundColor: Colors.grey.shade50,
+      appBar: AppBar(
+        elevation: 0.6,
+        backgroundColor: Colors.white,
+        centerTitle: false,
+        title: const Row(
+          children: [
+            Icon(Icons.book_outlined, color: primaryOrange),
+            SizedBox(width: 8),
+            Text('출석부', style: TextStyle(color: Colors.black87, fontWeight: FontWeight.w600)),
+          ],
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh, color: Colors.grey),
+            onPressed: _resetProfile,
+            tooltip: '프로필 초기화',
+          ),
+          if (_isLoading)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 24.0),
+              child: SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2.0)),
+            )
+          else
+            Padding(
+              padding: const EdgeInsets.only(right: 12, top: 8, bottom: 8),
+              child: Row(
+                children: [
+                  Text(name, style: TextStyle(color: Colors.grey.shade700)),
+                  const SizedBox(width: 10),
+                  GestureDetector(
+                    onTap: _showEditProfileDialog,
+                    child: CircleAvatar(
+                      radius: 18,
+                      backgroundColor: primaryOrange,
+                      child: Text(
+                        name.isNotEmpty ? name[0] : '?',
+                        style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            '오른쪽 상단 프로필을 눌러 정보를 수정하세요.\n앱을 종료해도 데이터는 유지됩니다.',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 16, color: Colors.grey),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// -----------------------------------------------------------------------------
+// 다이얼로그의 내용물을 별도의 StatefulWidget으로 분리
+// -----------------------------------------------------------------------------
+class EditProfileDialog extends StatefulWidget {
+  final String initialName;
+  final String initialStudentId;
+  final String initialPhone;
+  final String initialEmail;
+  final Future<void> Function(String name, String studentId, String phone, String email) onSave;
+
+  const EditProfileDialog({
+    super.key,
+    required this.initialName,
+    required this.initialStudentId,
+    required this.initialPhone,
+    required this.initialEmail,
+    required this.onSave,
+  });
+
+  @override
+  State<EditProfileDialog> createState() => _EditProfileDialogState();
+}
+
+class _EditProfileDialogState extends State<EditProfileDialog> {
+  // State 내부에 컨트롤러를 선언합니다.
+  late final TextEditingController nameController;
+  late final TextEditingController idController;
+  late final TextEditingController phoneController;
+  late final TextEditingController emailController;
+
+  @override
+  void initState() {
+    super.initState();
+    // initState에서 컨트롤러를 안전하게 생성합니다.
+    nameController = TextEditingController(text: widget.initialName);
+    idController = TextEditingController(text: widget.initialStudentId);
+    phoneController = TextEditingController(text: widget.initialPhone);
+    emailController = TextEditingController(text: widget.initialEmail);
+  }
+
+  @override
+  void dispose() {
+    // 위젯이 제거될 때 Flutter가 자동으로 호출해주는 dispose에서 컨트롤러를 해제합니다.
+    nameController.dispose();
+    idController.dispose();
+    phoneController.dispose();
+    emailController.dispose();
+    super.dispose();
+  }
+
+  // 재사용 가능한 입력 필드 위젯
+  Widget _buildInputField({
+    required TextEditingController controller,
+    required String hint,
+    required IconData icon,
+  }) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        prefixIcon: Icon(icon, color: Colors.grey.shade600),
+        hintText: hint,
+        contentPadding: const EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: Colors.grey.shade300),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: Colors.grey.shade300),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: primaryOrange, width: 1.5),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('프로필 수정', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+                  IconButton(
+                    splashRadius: 20,
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  )
+                ],
+              ),
+              const SizedBox(height: 8),
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 8),
+                child: ValueListenableBuilder<TextEditingValue>(
+                  valueListenable: nameController,
+                  builder: (context, value, _) {
+                    final txt = value.text;
+                    final firstChar = txt.isNotEmpty ? txt[0] : (widget.initialName.isNotEmpty ? widget.initialName[0] : '?');
+                    return CircleAvatar(
+                      radius: 36,
+                      backgroundColor: primaryOrange.withOpacity(0.1),
+                      child: Text(
+                        firstChar,
+                        style: const TextStyle(fontSize: 28, color: primaryOrange, fontWeight: FontWeight.w600),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 6),
+              _buildInputField(controller: nameController, hint: '이름', icon: Icons.person),
+              const SizedBox(height: 10),
+              _buildInputField(controller: idController, hint: '학번', icon: Icons.bookmark_outline),
+              const SizedBox(height: 10),
+              _buildInputField(controller: phoneController, hint: '전화번호', icon: Icons.phone),
+              const SizedBox(height: 10),
+              _buildInputField(controller: emailController, hint: '이메일', icon: Icons.email_outlined),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      foregroundColor: Colors.black87,
+                      backgroundColor: Colors.white,
+                      side: BorderSide(color: Colors.grey.shade300, width: 1),
+                    ),
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('취소'),
+                  ),
+                  const SizedBox(width: 12),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: primaryOrange,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    ),
+                    onPressed: () async {
+                      // 변경된 값을 onSave 콜백으로 전달
+                      await widget.onSave(
+                        nameController.text.trim(),
+                        idController.text.trim(),
+                        phoneController.text.trim(),
+                        emailController.text.trim(),
+                      );
+                      if (mounted) {
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    child: const Text('저장'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/HomeTab/Views/InOutStateView.dart
+++ b/frontend/lib/HomeTab/Views/InOutStateView.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+
+// 랩실 상태를 정의하는 enum
+enum LabStatus { inLab, outLab }
+
+const Color White = Color(0xFFFFFFFF);
+const Color Grey = Color(0xFF9CA3AF);
+const Color LightGrey = Color(0xFFE5E7EB); // 비활성화된 버튼 배경색
+
+// 화면의 한 부분을 구성하는 메인 상태 관리 위젯
+class LabStatusCard extends StatefulWidget {
+  const LabStatusCard({super.key});
+
+  @override
+  State<LabStatusCard> createState() => _LabStatusCardState();
+}
+
+class _LabStatusCardState extends State<LabStatusCard> {
+  // 현재 랩실 상태를 저장하는 변수 (기본값: 랩실 밖에 있음)
+  LabStatus _currentStatus = LabStatus.outLab;
+
+  // 상태 업데이트 함수
+  void _updateStatus(LabStatus newStatus) {
+    if (_currentStatus != newStatus) {
+      setState(() {
+        _currentStatus = newStatus;
+      });
+      // 실제 로직에서는 여기에 서버 통신 등을 추가합니다.
+      print('Status updated to: ${_currentStatus == LabStatus.inLab ? 'In Lab' : 'Out Lab'}');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 시각적 구분을 위해 Card 위젯 사용
+    return Card(
+      // 카드 내부의 여백 설정
+      margin: const EdgeInsets.all(16.0),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        // 모든 요소를 세로로 배치
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
+          children: [
+            // 1. 섹션 제목
+            const Text(
+              '랩실 상태',
+              style: TextStyle(
+                fontSize: 15.3,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16), // 간격
+
+            // 2. 현재 상태 표시 영역 (상태 변수에 따라 텍스트/색상 변경)
+            _CurrentStatus(status: _currentStatus),
+            const SizedBox(height: 16), // 간격
+
+            // 3. 들어오기/나가기 버튼 영역 (상태 업데이트 함수 전달)
+            _InOutButtons(
+              currentStatus: _currentStatus,
+              onUpdateStatus: _updateStatus,
+            ),
+            const SizedBox(height: 16), // 간격
+
+            // 4. 직접 상태 변경 토글 영역
+            const _ManualToggle(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// --- 하위 위젯들을 분리하여 구현 (가독성 향상) ---
+
+// 2. 현재 상태 표시 위젯 (LabStatus를 받아 상태에 따라 내용 변경)
+class _CurrentStatus extends StatelessWidget {
+  final LabStatus status;
+  const _CurrentStatus({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    // 상태에 따른 텍스트 및 색상 설정
+    final isInLab = status == LabStatus.inLab;
+    final statusText = isInLab ? '랩실 안에 있습니다' : '랩실 밖에 있습니다';
+    final statusDetail = isInLab ? '마지막 체크인: 오늘 09:45' : '마지막 체크아웃: 어제 18:30';
+    final statusColor = isInLab ? Colors.green.shade600 : Grey;
+
+    // 아이콘과 텍스트를 가로로 배치
+    return Row(
+      children: [
+        // 시계 아이콘 (색상 변화)
+        Icon(Icons.schedule, size: 64, color: statusColor),
+        const SizedBox(width: 16),
+        // 상태 텍스트
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              statusText,
+              style: TextStyle(
+                fontSize: 15.3,
+                color: statusColor, // 색상 변화
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Text(
+                statusDetail,
+                style: const TextStyle(fontSize: 11.9, color: Grey)
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+// 3. 들어오기/나가기 버튼 위젯 (상태에 따라 스타일 변화)
+class _InOutButtons extends StatelessWidget {
+  final LabStatus currentStatus;
+  final Function(LabStatus) onUpdateStatus;
+
+  const _InOutButtons({required this.currentStatus, required this.onUpdateStatus});
+
+  @override
+  Widget build(BuildContext context) {
+    final isInLab = currentStatus == LabStatus.inLab;
+
+    // --- 버튼 스타일 정의 ---
+
+    // 랩실 '안에 있음' 버튼 스타일 (선택/비선택)
+    final inStyle = ElevatedButton.styleFrom(
+      backgroundColor: isInLab ? Colors.deepOrange : LightGrey, // 선택되면 주황, 아니면 밝은 회색
+      foregroundColor: isInLab ? White : Grey, // 선택되면 흰색, 아니면 회색
+      minimumSize: const Size(double.infinity, 80),
+      elevation: isInLab ? 4 : 0, // 선택되면 그림자 추가
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+    );
+
+    // 랩실 '밖에 있음' 버튼 스타일 (선택/비선택)
+    final outStyle = ElevatedButton.styleFrom(
+      backgroundColor: !isInLab ? Colors.deepOrange : LightGrey, // 선택되면 주황, 아니면 밝은 회색
+      foregroundColor: !isInLab ? White : Grey, // 선택되면 흰색, 아니면 회색
+      minimumSize: const Size(double.infinity, 80),
+      elevation: !isInLab ? 4 : 0, // 선택되면 그림자 추가
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+    );
+
+    return Row(
+      children: [
+        // 들어오기 버튼 (IN_LAB)
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(right: 4.0), // 버튼 사이 간격 조정
+            child: ElevatedButton.icon(
+              onPressed: () => onUpdateStatus(LabStatus.inLab),
+              icon: const Icon(Icons.arrow_forward_ios, size: 20),
+              label: const Text('들어오기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              style: inStyle,
+            ),
+          ),
+        ),
+
+        // 나가기 버튼 (OUT_LAB)
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 4.0), // 버튼 사이 간격 조정
+            child: ElevatedButton.icon(
+              onPressed: () => onUpdateStatus(LabStatus.outLab),
+              icon: const Icon(Icons.arrow_back_ios, size: 20),
+              label: const Text('나가기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              style: outStyle,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// 4. 직접 상태 변경 토글 위젯
+class _ManualToggle extends StatefulWidget {
+  const _ManualToggle();
+
+  @override
+  State<_ManualToggle> createState() => _ManualToggleState();
+}
+
+class _ManualToggleState extends State<_ManualToggle> {
+  bool _isManualEnabled = false; // 토글 상태 변수
+
+  @override
+  Widget build(BuildContext context) {
+    // 텍스트와 스위치를 가로로 배치
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween, // 양쪽 끝으로 벌림
+      children: [
+        const Text('직접 상태 변경', style: TextStyle(fontSize: 14, color: Grey)),
+        // 토글 스위치 (상태 관리 필요)
+        Switch(
+          value: _isManualEnabled,
+          onChanged: (bool newValue) {
+            setState(() {
+              _isManualEnabled = newValue;
+            });
+            // 로직: 수동 상태 변경이 켜지면 자동 감지 기능을 끄는 등의 로직 구현
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/HomeTab/Views/Profile_Service.dart
+++ b/frontend/lib/HomeTab/Views/Profile_Service.dart
@@ -1,0 +1,49 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ProfileService {
+  // SharedPreferences에 데이터를 저장할 때 사용할 키(key)
+  static const String _nameKey = 'profile_name';
+  static const String _studentIdKey = 'profile_student_id';
+  static const String _phoneKey = 'profile_phone';
+  static const String _emailKey = 'profile_email';
+
+  // 프로필 정보를 SharedPreferences에 생성 & 수정 하는 메소드
+  Future<void> saveProfile({
+    required String name,
+    required String studentId,
+    required String phone,
+    required String email,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_nameKey, name);
+    await prefs.setString(_studentIdKey, studentId);
+    await prefs.setString(_phoneKey, phone);
+    await prefs.setString(_emailKey, email);
+  }
+
+  // SharedPreferences에서 프로필 정보를 불러오는 메소드
+  Future<Map<String, String>> loadProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    // 저장된 값이 없을 경우 기본값을 반환
+    final name = prefs.getString(_nameKey) ?? '김학생';
+    final studentId = prefs.getString(_studentIdKey) ?? '20230123';
+    final phone = prefs.getString(_phoneKey) ?? '010-1234-5678';
+    final email = prefs.getString(_emailKey) ?? 'student@university.ac.kr';
+
+    return {
+      'name': name,
+      'studentId': studentId,
+      'phone': phone,
+      'email': email,
+    };
+  }
+
+  // (추가) 프로필 정보 초기화(삭제) 메소드
+  Future<void> clearProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_nameKey);
+    await prefs.remove(_studentIdKey);
+    await prefs.remove(_phoneKey);
+    await prefs.remove(_emailKey);
+  }
+}

--- a/frontend/lib/MemberTab/MemberStateView.dart
+++ b/frontend/lib/MemberTab/MemberStateView.dart
@@ -1,0 +1,219 @@
+// lib/attendance_view.dart
+import 'package:flutter/material.dart';
+import 'package:frontend/TabBar/Shared_widgets.dart';
+
+// =======================================================
+// 출석뷰 메인 화면 위젯
+// =======================================================
+class AttendanceViewScreenContent extends StatelessWidget {
+  const AttendanceViewScreenContent({super.key});
+
+  // private 헬퍼 함수들은 이 파일 안에 두어도 됩니다.
+  Widget _buildColorIndicator(Color color) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 2),
+      width: 30,
+      height: 10,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(2),
+      ),
+    );
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    // Scaffold, AppBar 없이 내용만 반환
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(12.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          // ⭐ 1. 기존 AppBar에서 가져온 '김학생' 프로필 정보를 재구성
+          Padding(
+            padding: const EdgeInsets.only(bottom: 20.0), // 하단 간격 추가
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end, // 오른쪽 끝으로 정렬
+              children: [
+                const Text('김학생', style: TextStyle(color: Colors.black)),
+                const SizedBox(width: 4),
+                Container(
+                  width: 30,
+                  height: 30,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: Colors.deepOrange,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Text(
+                    '김',
+                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // ⭐ 2. '랩실 구성원 출석 현황' 타이틀
+          const Text(
+            '랩실 구성원 출석 현황',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+
+          const SizedBox(height: 16),
+
+          // 3. 출석 빈도 (Colors.deepOrange를 bgc로 바꿀 수 있지만 기존 색상 유지)
+          Row(
+            children: [
+              const Text('출석 빈도:', style: TextStyle(color: Colors.grey)),
+              const SizedBox(width: 8),
+              _buildColorIndicator(Colors.amber.shade100),
+              _buildColorIndicator(Colors.amber.shade200),
+              _buildColorIndicator(Colors.amber.shade400),
+              _buildColorIndicator(Colors.deepOrange.shade400),
+            ],
+          ),
+
+          const SizedBox(height: 20),
+
+          // 4. AttendanceTile 목록
+          const AttendanceTile(
+            name: '김학생',
+            major: '박사과정',
+            initials: '김',
+            color: Colors.deepOrange,
+            attendanceRate: 85,
+            initiallyExpanded: true,
+          ),
+          const SizedBox(height: 16),
+          // ... (나머지 AttendanceTile 목록) ...
+        ],
+      ),
+    );
+  }
+}
+
+// =======================================================
+// 확장 가능한 출석 항목 위젯 (Customized ExpansionTile)
+// =======================================================
+class AttendanceTile extends StatelessWidget {
+  final String name;
+  final String major;
+  final String initials;
+  final Color color;
+  final int attendanceRate;
+  final bool initiallyExpanded;
+
+  const AttendanceTile({
+    super.key,
+    required this.name,
+    required this.major,
+    required this.initials,
+    required this.color,
+    required this.attendanceRate,
+    this.initiallyExpanded = false,
+  });
+
+  Widget _buildCustomTitle(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        children: <Widget>[
+          Container(
+            width: 40,
+            height: 40,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.8),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              initials,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                fontSize: 16,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text(
+                  name,
+                  style: const TextStyle(
+                      fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+                Text(
+                  major,
+                  style: const TextStyle(color: Colors.grey, fontSize: 14),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                '$attendanceRate %',
+                style: const TextStyle(
+                    fontWeight: FontWeight.bold, fontSize: 16),
+              ),
+              const Text(
+                '출석률',
+                style: TextStyle(color: Colors.grey, fontSize: 12),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildExpandedChildren() {
+    return <Widget>[
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.symmetric(
+            horizontal: 20.0, vertical: 15.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+          ],
+        ),
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 4.0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16.0),
+      ),
+      margin: EdgeInsets.zero,
+      child: Theme(
+        data: Theme.of(context).copyWith(
+          dividerColor: Colors.transparent,
+          listTileTheme: const ListTileThemeData(
+            contentPadding: EdgeInsets.symmetric(horizontal: 12),
+          ),
+        ),
+        child: ExpansionTile(
+          initiallyExpanded: initiallyExpanded,
+          controlAffinity: ListTileControlAffinity.trailing,
+          iconColor: Colors.grey,
+          collapsedIconColor: Colors.grey,
+          title: _buildCustomTitle(context),
+          children: _buildExpandedChildren(),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/TabBar/Shared_widgets.dart
+++ b/frontend/lib/TabBar/Shared_widgets.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+// ⭐ BottomNavigationBar 위젯을 별도의 StatelessWidget으로 분리
+class CustomBottomNavBar extends StatelessWidget {
+  final int currentIndex;
+  final Function(int)? onItemSelected; // 탭 전환 로직을 받기 위한 함수
+
+  const CustomBottomNavBar({
+    super.key,
+    required this.currentIndex,
+    this.onItemSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      selectedItemColor: Colors.deepOrange,
+      unselectedItemColor: Colors.grey,
+      // 선택 이벤트 핸들러 추가 (탭 전환 로직이 있다면 사용)
+      onTap: onItemSelected,
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(icon: Icon(Icons.home_outlined), label: '홈'),
+        BottomNavigationBarItem(icon: Icon(Icons.people_alt_outlined), label: '구성원'),
+        BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: '잔류현황'),
+      ],
+      currentIndex: currentIndex,
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
-
+import 'package:frontend/HomeTab/Views/InOutStateView.dart';
 void main() {
   runApp(const MyApp());
 }
+
+const BGC = Color(0xFFFFFFFF);
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -11,26 +13,11 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: '랩실 출석부',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(seedColor: BGC),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(title: '랩실 출석부'),
     );
   }
 }
@@ -54,69 +41,22 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter--;
-    });
-  }
+
+
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
+        backgroundColor: BGC,
         title: Text(widget.title),
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
+      body: ListView(
+        children: const <Widget>[
+          LabStatusCard(),
+        ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Decrement',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/HomeTab/Views/InOutStateView.dart';
+import 'package:frontend/MemberTab/MemberStateView.dart';
+import 'package:frontend/TabBar/Shared_widgets.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -8,6 +11,8 @@ const BGC = Color(0xFFFFFFFF);
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
+
+
 
   // This widget is the root of your application.
   @override
@@ -41,21 +46,63 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  // ⭐ 1. 현재 선택된 탭의 인덱스를 상태로 관리합니다. (홈: 0, 구성원: 1, 잔류현황: 2)
+  int _selectedIndex = 0;
 
+  // ⭐ 2. 탭에 따라 body에 표시할 위젯 목록을 정의합니다.
+  static final List<Widget> _widgetOptions = <Widget>[
+    // [0] 홈 화면 (기존 MyHomePage의 body 내용)
+    ListView(
+      children: const <Widget>[
+        // LabStatusCard는 이 파일 또는 다른 파일에 정의되어 있어야 합니다.
+        LabStatusCard(),
+      ],
+    ),
 
+    // [1] 구성원 화면 (MemberStateView.dart의 내용물)
+    // AttendanceViewScreenContent는 Scaffold, AppBar, BottomBar가 없는 순수 내용물입니다.
+    const AttendanceViewScreenContent(),
 
+    // [2] 잔류현황 화면 (임시 위젯)
+    const Center(
+      child: Text(
+        '잔류현황 화면 내용',
+        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      ),
+    ),
+  ];
+
+  // ⭐ 3. BottomNavigationBar 탭 클릭 시 인덱스 업데이트 함수
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  // 이전의 _navigateToMemberStateView 함수는 이제 필요 없습니다.
 
   @override
   Widget build(BuildContext context) {
+    // 현재 선택된 인덱스에 따라 AppBar의 타이틀을 변경할 수 있습니다.
+    String currentTitle = widget.title;
+    if (_selectedIndex == 1) {
+      currentTitle = '출석뷰'; // 구성원 탭을 눌렀을 때 타이틀 변경
+    }
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: BGC,
-        title: Text(widget.title),
+        title: Text(currentTitle),
+        // 필요하다면 앱바의 Actions(오른쪽 상단)도 여기에 배치할 수 있습니다.
       ),
-      body: ListView(
-        children: const <Widget>[
-          LabStatusCard(),
-        ],
+
+      // ⭐ 4. body에 현재 선택된 인덱스의 위젯을 표시합니다.
+      body: _widgetOptions.elementAt(_selectedIndex),
+
+      // ⭐ 5. BottomNavigationBar를 CustomBottomNavBar로 연결
+      bottomNavigationBar: CustomBottomNavBar(
+        currentIndex: _selectedIndex, // 현재 인덱스를 BottomBar에 전달
+        onItemSelected: _onItemTapped, // 클릭 이벤트를 _onItemTapped에 연결
       ),
     );
   }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -72,6 +88,11 @@ packages:
     version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -139,6 +160,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.15"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "1c33a907142607c40a7542768ec9badfd16293bac51da3a4482623d15845f88b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +325,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
-  dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
+  shared_preferences: ^2.2.2
   cupertino_icons: ^1.0.8
 
 dev_dependencies:


### PR DESCRIPTION
## 🔨작업 내용
- 홈 화면에서 랩실 구성원 화면으로 이동하는 로직 구현
- 이동 시 초기에는 화면 중앙의 페이지 이동 버튼을 표시해 버튼 누를시 이동하는 구조였으나 이후 수정하여 화면 하단의 appbar에서 페이지 이동하는 형식으로 구현함
- 랩실 구성원 페이지에서 각 구성원의 상세 정보를 확인할 수 있도록 화살표 이용해 구성원 정보 펼치기 기능 구현
- 현재는 구성원 상세 정보란을 비워둔 상태
## 📸이미지 첨부(API 요청/응답 형식 및 실제 동작 또는 UI변경)
<img width="390" height="858" alt="image" src="https://github.com/user-attachments/assets/74d93dec-67ff-424c-8a4a-c99541bb5404" />
<img width="405" height="882" alt="image" src="https://github.com/user-attachments/assets/31b7d768-8435-466d-8580-e6736b671f7e" />
<img width="369" height="100" alt="image" src="https://github.com/user-attachments/assets/8d0915df-37ba-4afd-a75c-e71faece365e" />

## ❗️관련된 이슈
## 🤔고려사항
- 직전 주차에 구현했던 한달 간 랩실 출석 기록표를 어떻게 구성원 상세정보 탭에 연결할지를 고민해봐야 할것 같습니다