### PR TITLE
docs: API 명세 작성(swagger)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Attendance/AttendanceController.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Attendance/AttendanceController.java
@@ -1,20 +1,33 @@
 package com.example.LabAttendance.RollCall.Attendance;
 
-
 import com.example.LabAttendance.RollCall.InOut.Dto.CheckInDto;
 import com.example.LabAttendance.RollCall.global.Exception.AlreadyCheckInException;
 import com.example.LabAttendance.RollCall.global.Exception.NotAttendanceTodayException;
 import com.example.LabAttendance.RollCall.global.ResponneType.ApiResponse;
 import com.example.LabAttendance.RollCall.global.ResponneType.NoDataApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(
+        name = "Lab Attendance",
+        description = """
+                실험실 출석 관리 API
+
+                - 인증된 사용자(memberId)를 기준으로 출석을 관리합니다.
+                - 체크인: 오늘 날짜 기준 입실 기록을 생성합니다.
+                - 체크아웃: 특정 체크인 기록(checkInId)에 대해 퇴실을 처리합니다.
+                """
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lab/attendance")
@@ -22,37 +35,200 @@ public class AttendanceController {
 
     private final AttendanceService attendanceService;
 
+    @Operation(
+            summary = "체크인 (입실)",
+            description = """
+                    오늘 날짜 기준으로 실험실 **체크인(입실)** 을 수행합니다.
+
+                    ### 처리 흐름
+                    1. 인증된 사용자 ID(memberId)를 SecurityContext에서 가져옵니다.
+                    2. 오늘 체크인 기록이 없다면 새로운 체크인 기록을 생성합니다.
+                    3. 생성된 체크인 ID를 `CheckInDto`로 감싸 반환합니다.
+
+                    ### 실패 조건
+                    - 이미 오늘 체크인을 완료한 경우 체크인이 거부됩니다.
+                    """,
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "체크인 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "check-in-success",
+                                            summary = "체크인 성공 응답",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "message": "체크인 되었습니다.",
+                                                      "data": {
+                                                        "checkInId": 15
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "이미 체크인한 상태",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "already-checked-in",
+                                            summary = "중복 체크인 실패",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "message": "이미 체크인 되어 있습니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
     @PostMapping("/in")
     public ResponseEntity<ApiResponse<CheckInDto>> checkIn(
-            @AuthenticationPrincipal Long memberId)
-            {
-        try{
+            @Parameter(
+                    name = "memberId",
+                    description = """
+                            인증된 사용자 식별자  
+                            - JWT 또는 세션 인증 후 SecurityContext에서 주입됩니다.
+                            - 요청 바디나 쿼리 파라미터로 전달되지 않습니다.
+                            """,
+                    in = ParameterIn.HEADER,
+                    required = true,
+                    example = "101"
+            )
+            @AuthenticationPrincipal Long memberId
+    ) {
+        try {
             return ResponseEntity.status(200)
                     .body(ApiResponse.success(
-                            new CheckInDto(attendanceService.checkInLab(memberId)),"체크인 되었습니다."));
-        }catch (AlreadyCheckInException e){
-            return ResponseEntity.status(400).body(ApiResponse.failure(e.getMessage()));
+                            new CheckInDto(attendanceService.checkInLab(memberId)),
+                            "체크인 되었습니다."
+                    ));
+        } catch (AlreadyCheckInException e) {
+            return ResponseEntity.status(400)
+                    .body(ApiResponse.failure(e.getMessage()));
         }
     }
 
+    @Operation(
+            summary = "체크아웃 (퇴실)",
+            description = """
+                    체크인 기록(checkInId)에 대해 실험실 **체크아웃(퇴실)** 을 수행합니다.
+
+                    ### 처리 흐름
+                    1. 인증된 사용자 ID(memberId)를 확인합니다.
+                    2. 전달된 checkInId가 오늘의 체크인 기록인지 검증합니다.
+                    3. 정상적인 경우 체크아웃 시간을 기록합니다.
+
+                    ### 실패 조건
+                    - 오늘 체크인 기록이 없는 경우
+                    - 이미 체크아웃이 완료된 경우
+                    - checkInId가 존재하지 않는 경우
+                    """,
+            parameters = {
+                    @Parameter(
+                            name = "inout_id",
+                            description = "체크아웃 처리할 체크인 ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            example = "15"
+                    )
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "체크아웃 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = NoDataApiResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "check-out-success",
+                                            summary = "체크아웃 성공 응답",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "message": "체크아웃 되었습니다"
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "체크아웃 불가 (체크인 없음 또는 중복 처리)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = NoDataApiResponse.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    name = "no-checkin-today",
+                                                    summary = "오늘 체크인 기록 없음",
+                                                    value = """
+                                                            {
+                                                              "success": false,
+                                                              "message": "체크인 먼저 진행해주세요"
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "already-checked-out",
+                                                    summary = "이미 체크아웃됨",
+                                                    value = """
+                                                            {
+                                                              "success": false,
+                                                              "message": "이미 처리된 출석 기록입니다."
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "체크인 기록 없음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = NoDataApiResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "checkin-not-found",
+                                            summary = "존재하지 않는 checkInId",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "message": "해당 기록을 찾을 수 없습니다."
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
     @PostMapping("/out/{inout_id}")
     public ResponseEntity<NoDataApiResponse> checkOut(
             @AuthenticationPrincipal Long memberId,
-            @PathVariable(name ="inout_id") Long inoutId
-    ){
-        try{
+            @PathVariable(name = "inout_id") Long inoutId
+    ) {
+        try {
             attendanceService.checkOutLab(memberId, inoutId);
             return ResponseEntity.status(200)
                     .body(NoDataApiResponse.success("체크아웃 되었습니다"));
-        }catch (NotAttendanceTodayException e){
+        } catch (NotAttendanceTodayException e) {
             return ResponseEntity.status(400)
                     .body(NoDataApiResponse.failure("체크인 먼저 진행해주세요"));
-        }catch (AlreadyCheckInException e){
-            return ResponseEntity.status(400).body(NoDataApiResponse.failure(e.getMessage()));
-        }catch(EntityNotFoundException e){
-            return ResponseEntity.status(404).body(NoDataApiResponse.failure(e.getMessage()));
+        } catch (AlreadyCheckInException e) {
+            return ResponseEntity.status(400)
+                    .body(NoDataApiResponse.failure(e.getMessage()));
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(404)
+                    .body(NoDataApiResponse.failure(e.getMessage()));
         }
     }
-
-
 }

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberController.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/Member/MemberController.java
@@ -1,72 +1,224 @@
 package com.example.LabAttendance.RollCall.Member;
 
-import com.example.LabAttendance.RollCall.Member.DTO.MemberSignupRequestDto;
-
+import com.example.LabAttendance.RollCall.Member.DTO.*;
 import com.example.LabAttendance.RollCall.global.Exception.DuplicateEmailException;
 import com.example.LabAttendance.RollCall.global.Exception.MemberNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.HttpStatus;
-import jakarta.validation.Valid;
-import com.example.LabAttendance.RollCall.Member.DTO.*;
-import org.springframework.security.authentication.BadCredentialsException;
 
+@Tag(
+        name = "Member",
+        description = """
+                회원 관리 API
+
+                - 회원 가입
+                - 로그인
+                - 이메일 중복, 인증 실패 등의 예외를 처리합니다.
+                """
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lab/users")
-public class MemberController
-{
+public class MemberController {
+
     private final MemberService memberService;
 
+    @Operation(
+            summary = "회원 가입",
+            description = """
+                    신규 사용자를 회원으로 등록합니다.
+
+                    ### 처리 흐름
+                    1. 요청 바디(MemberSignupRequestDto)의 유효성을 검증합니다.
+                    2. 이메일 중복 여부를 확인합니다.
+                    3. 회원 정보를 저장하고 생성된 회원 정보를 반환합니다.
+
+                    ### 실패 조건
+                    - 입력값 검증 실패 (400)
+                    - 이메일 중복 (409)
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "회원 가입 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MemberResponseDto.class),
+                                    examples = @ExampleObject(
+                                            name = "signup-success",
+                                            summary = "회원 가입 성공",
+                                            value = """
+                                                    {
+                                                      "id": 1,
+                                                      "email": "test@test.com",
+                                                      "name": "홍길동"
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "입력값 검증 실패",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "validation-error",
+                                            summary = "Validation Error",
+                                            value = """
+                                                    [
+                                                      {
+                                                        "field": "email",
+                                                        "defaultMessage": "이메일 형식이 올바르지 않습니다."
+                                                      }
+                                                    ]
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "이메일 중복",
+                            content = @Content(
+                                    mediaType = "text/plain",
+                                    examples = @ExampleObject(
+                                            name = "duplicate-email",
+                                            summary = "이메일 중복",
+                                            value = "이미 사용 중인 이메일입니다."
+                                    )
+                            )
+                    )
+            }
+    )
     @PostMapping("/sign")
-    public ResponseEntity<?> signup(@Valid @RequestBody MemberSignupRequestDto requestDto,
-                                    BindingResult bindingResult)
-    {
-        if (bindingResult.hasErrors())
-        {
+    public ResponseEntity<?> signup(
+            @Valid @RequestBody MemberSignupRequestDto requestDto,
+            BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
             return ResponseEntity.badRequest().body(bindingResult.getFieldErrors());
         }
 
         MemberResponseDto responseDto;
-        try
-        {
+        try {
             responseDto = memberService.create(requestDto);
-        }
-        catch (DuplicateEmailException e)
-        {
+        } catch (DuplicateEmailException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
+
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
+    @Operation(
+            summary = "로그인",
+            description = """
+                    사용자의 이메일과 비밀번호로 로그인을 수행합니다.
+
+                    ### 처리 흐름
+                    1. 이메일 / 비밀번호 유효성 검증
+                    2. 사용자 인증
+                    3. 인증 성공 시 로그인 응답 정보 반환
+
+                    ### 실패 조건
+                    - 이메일 또는 비밀번호 불일치 (401)
+                    - 입력값 검증 실패 (400)
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = LoginResponseDto.class),
+                                    examples = @ExampleObject(
+                                            name = "login-success",
+                                            summary = "로그인 성공",
+                                            value = """
+                                                    {
+                                                      "memberId": 1,
+                                                      "email": "test@test.com",
+                                                      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "입력값 검증 실패",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "validation-error",
+                                            summary = "Validation Error",
+                                            value = """
+                                                    [
+                                                      {
+                                                        "field": "password",
+                                                        "defaultMessage": "비밀번호는 필수 입력값입니다."
+                                                      }
+                                                    ]
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패",
+                            content = @Content(
+                                    mediaType = "text/plain",
+                                    examples = @ExampleObject(
+                                            name = "login-fail",
+                                            summary = "로그인 실패",
+                                            value = "이메일 또는 비밀번호가 일치하지 않습니다."
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 오류",
+                            content = @Content(
+                                    mediaType = "text/plain",
+                                    examples = @ExampleObject(
+                                            name = "server-error",
+                                            summary = "서버 오류",
+                                            value = "서버 오류 발생"
+                                    )
+                            )
+                    )
+            }
+    )
     @PostMapping("/login")
-    public ResponseEntity<?> login
-            (@Valid @RequestBody LoginRequestDto loginRequestDto,
-             BindingResult bindingResult) {
+    public ResponseEntity<?> login(
+            @Valid @RequestBody LoginRequestDto loginRequestDto,
+            BindingResult bindingResult
+    ) {
         if (bindingResult.hasErrors()) {
             return ResponseEntity.badRequest().body(bindingResult.getFieldErrors());
         }
 
         LoginResponseDto responseDto;
 
-        try
-        {
+        try {
             responseDto = memberService.login(loginRequestDto);
-        }
-        catch (MemberNotFoundException | BadCredentialsException e)
-        {
-            // 이메일 불일치, 비밀번호 불일치 오류는 401 반환
+        } catch (MemberNotFoundException | BadCredentialsException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("이메일 또는 비밀번호가 일치하지 않습니다.");
-        }
-        catch (Exception e)
-        {
-            // 500 오류 시, 상세한 오류 정보를 반환하여 디버깅을 돕습니다. (임시 코드)
-            e.printStackTrace(); // 서버 콘솔에 스택 트레이스를 출력
+        } catch (Exception e) {
+            e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("서버 오류 발생: " + e.getMessage()); // Postman에 오류 메시지 노출
+                    .body("서버 오류 발생: " + e.getMessage());
         }
 
         return ResponseEntity.ok(responseDto);

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/SecurityConfig.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/SecurityConfig.java
@@ -50,9 +50,17 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         // H2 Console 경로 허용
                         .requestMatchers(PathRequest.toH2Console()).permitAll()
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+
 
                         // 회원가입 및 로그인 경로는 인증 없이 접근 허용
-                        .requestMatchers("/lab/users/sign", "/lab/users/login").permitAll()
+                        .requestMatchers(
+                                "/lab/users/sign",
+                                "/lab/users/login",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                                ).permitAll()
 
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/global/jwt/JwtAuthenticationFilter.java
@@ -20,18 +20,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
     @Override
-    protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
-    ) throws ServletException, IOException {
-
-        if (request.getRequestURI().equals("/lab/users/sign") ||
-                request.getRequestURI().equals("/lab/users/login")
-        ) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
 
         String token = resolveToken(request);
 
@@ -43,6 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+
     private String resolveToken(HttpServletRequest request) {
         String header = request.getHeader("Authorization");
 
@@ -52,4 +45,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return null;
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+
+        return uri.startsWith("/swagger-ui")
+                || uri.startsWith("/v3/api-docs")
+                || uri.equals("/swagger-ui.html")
+                || uri.startsWith("/h2-console")
+                || uri.equals("/lab/users/sign")
+                || uri.equals("/lab/users/login");
+    }
+
 }

--- a/backend/src/main/java/com/example/LabAttendance/RollCall/stay/StayController.java
+++ b/backend/src/main/java/com/example/LabAttendance/RollCall/stay/StayController.java
@@ -5,6 +5,13 @@ import com.example.LabAttendance.RollCall.Attendance.Dto.DailyStayDto;
 import com.example.LabAttendance.RollCall.InOut.Dto.InoutDto;
 import com.example.LabAttendance.RollCall.InOut.InOutService;
 import com.example.LabAttendance.RollCall.global.ResponneType.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(
+        name = "Lab Stay",
+        description = """
+                실험실 체류 시간 조회 API
+
+                - 사용자의 출석(체크인/체크아웃) 기록을 기반으로
+                  최근 체류 이력을 조회합니다.
+                - 주 단위(7일), 월 단위(30일) 조회를 제공합니다.
+                """
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lab/stay")
@@ -22,11 +39,55 @@ public class StayController {
     private final InOutService inOutService;
     private final AttendanceService attendanceService;
 
-    /**
-     * 최근 7일 체크인/체크아웃 조회
-     */
+    @Operation(
+            summary = "최근 7일 체크인/체크아웃 조회",
+            description = """
+                    최근 **7일간** 사용자의 체크인/체크아웃 기록을 조회합니다.
+
+                    ### 조회 기준
+                    - 인증된 사용자(memberId)
+                    - 오늘을 기준으로 과거 7일
+
+                    ### 반환 데이터
+                    - 날짜별 체크인/체크아웃 기록 목록
+                    """,
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "최근 7일 체크인/체크아웃 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "week-stay-success",
+                                            summary = "최근 7일 조회 성공",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "message": "최근 7일 체크인/체크아웃 조회 성공",
+                                                      "data": [
+                                                        { },
+                                                        { }
+                                                      ]
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
     @GetMapping("/week")
     public ResponseEntity<ApiResponse<List<InoutDto>>> getLast7Days(
+            @Parameter(
+                    name = "memberId",
+                    description = """
+                            인증된 사용자 식별자  
+                            - JWT 또는 세션 인증 이후 SecurityContext에서 주입됩니다.
+                            """,
+                    in = ParameterIn.HEADER,
+                    required = true,
+                    example = "101"
+            )
             @AuthenticationPrincipal Long memberId
     ) {
         List<InoutDto> result = inOutService.getLast7Days(memberId);
@@ -36,9 +97,43 @@ public class StayController {
         );
     }
 
-    /**
-     * 최근 30일 간 하루별 총 잔류 시간 조회
-     */
+    @Operation(
+            summary = "최근 30일 하루별 체류 시간 조회",
+            description = """
+                    최근 **30일간** 하루 단위로 사용자의 총 체류 시간을 조회합니다.
+
+                    ### 조회 기준
+                    - 인증된 사용자(memberId)
+                    - 하루 단위 집계 결과 반환
+
+                    ### 반환 데이터
+                    - 날짜별 총 체류 시간 목록
+                    """,
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "최근 30일 체류 시간 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "month-stay-success",
+                                            summary = "최근 30일 조회 성공",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "message": "최근 30일 잔류 시간 조회 성공",
+                                                      "data": [
+                                                        { },
+                                                        { }
+                                                      ]
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
     @GetMapping("/month")
     public ResponseEntity<ApiResponse<List<DailyStayDto>>> getLast30Days(
             @AuthenticationPrincipal Long memberId


### PR DESCRIPTION
## 🔨 작업 내용
- Swagger UI 레이아웃 깨짐 이슈 해결
- `springdoc-openapi` 버전을 **2.5.0 → 2.2.0**으로 다운그레이드
- JWT / Spring Security 설정은 변경 없이 유지하여 영향 범위 최소화

## 📸 이미지 첨부 (API 요청/응답 형식 및 실제 동작 또는 UI 변경)
- Swagger UI 정상 출력 확인
- API 목록 및 요청/응답 테스트 화면 정상 렌더링
- (필요 시 Swagger UI 정상 화면 캡처 첨부)

## ❗️ 관련된 이슈
- Swagger UI 접속 시 레이아웃 깨짐 현상 발생
- 정적 리소스 및 `/v3/api-docs`는 정상 동작하나 UI 렌더링이 비정상적으로 출력됨

## 🤔 고려사항
- 기존 프로젝트에서 안정적으로 사용 중이던 `springdoc-openapi 2.2.0` 버전으로 맞춰 안정성 우선 확보
- JWT 라이브러리 버전은 코드 의존성 이슈로 인해 이번 PR에서는 변경하지 않음
- Swagger 및 JWT 관련 추가 버전 업그레이드는 별도 PR로 분리 예정
